### PR TITLE
Add flag for adding target name to profraw file names

### DIFF
--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -35,6 +35,7 @@
 #import "XcodeBuildSettings.h"
 #import "XCTestConfiguration.h"
 #import "XCTestConfigurationUnarchiver.h"
+#import "Testable.h"
 
 @interface OCUnitTestRunner ()
 @property (nonatomic, copy) SimulatorInfo *simulatorInfo;
@@ -47,9 +48,11 @@ static id TestRunnerWithTestListsAndProcessEnv(Class cls, NSDictionary *settings
 
   EventBuffer *eventBuffer = [[EventBuffer alloc] init];
 
+  Testable *testable = [[Testable alloc] init];
   SimulatorInfo *simulatorInfo = [SimulatorInfo new];
   [simulatorInfo setDeviceName:kDefaultDeviceName];
   return [[cls alloc] initWithBuildSettings:settings
+                                   testable:testable
                               simulatorInfo:simulatorInfo
                            focusedTestCases:focusedTestCases
                                allTestCases:allTestCases

--- a/xctool/xctool-tests/OTestShimTests.m
+++ b/xctool/xctool-tests/OTestShimTests.m
@@ -26,6 +26,7 @@
 #import "TestUtil.h"
 #import "XCToolUtil.h"
 #import "XcodeBuildSettings.h"
+#import "Testable.h"
 
 @interface OTestShimTests : XCTestCase
 @end
@@ -110,10 +111,13 @@ static NSTask *OtestShimTask(NSString *platformName,
   targetSettings[Xcode_TARGET_BUILD_DIR] = [bundlePath stringByDeletingLastPathComponent];
   targetSettings[Xcode_FULL_PRODUCT_NAME] = [bundlePath lastPathComponent];
 
+  Testable *testable = [[Testable alloc] init];
+
   // set up an OCUnitIOSLogicTestRunner
   SimulatorInfo *simulatorInfo = [SimulatorInfo new];
   [simulatorInfo setDeviceName:kDefaultDeviceName];
   OCUnitIOSLogicTestRunner *runner = [[testRunnerClass alloc] initWithBuildSettings:targetSettings
+                                                                           testable:testable
                                                                       simulatorInfo:simulatorInfo
                                                                    focusedTestCases:focusedTests
                                                                        allTestCases:allTests

--- a/xctool/xctool/OCUnitTestRunner.h
+++ b/xctool/xctool/OCUnitTestRunner.h
@@ -19,6 +19,7 @@
 #import "SimulatorInfo.h"
 #import "TestRunState.h"
 #import "TestingFramework.h"
+#import "Testable.h"
 
 @interface OCUnitTestRunner : NSObject {
 @protected
@@ -38,6 +39,7 @@
   NSInteger _testTimeout;
   NSArray *_reporters;
   NSDictionary *_framework;
+  Testable *_testable;
 }
 
 @property (nonatomic, copy, readonly) NSArray *reporters;
@@ -60,6 +62,7 @@
                        error:(NSString **)error;
 
 - (instancetype)initWithBuildSettings:(NSDictionary *)buildSettings
+                             testable:(Testable *)testable
                         simulatorInfo:(SimulatorInfo *)simulatorInfo
                      focusedTestCases:(NSArray *)focusedTestCases
                          allTestCases:(NSArray *)allTestCases

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -767,6 +767,7 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
 {
   return [^(NSArray *reporters) {
     OCUnitTestRunner *testRunner = [[testRunnerClass alloc] initWithBuildSettings:testableExecutionInfo.buildSettings
+                                                                         testable:testable
                                                                     simulatorInfo:_simulatorInfo
                                                                  focusedTestCases:focusedTestCases
                                                                      allTestCases:allTestCases


### PR DESCRIPTION
- Adds a flag on the test runner to provide a directory for profraw files, which will also set profraw files to include the target name
- The target name is obtained from the Testable object, which needs to be passed in
- Update unit tests to address the updated init call

You provide the directory like so:
--test-runner-env XCTOOL_PROFILE_DIRECTORY="/path/to/folder"

The profraw name would be like:
code-toolbar_support_tests-42488-16902514831590228483_0.profraw

The format is
code-(simple target name)-(process id)-(binary's signature).profraw

There may be more than one profraw for the given target, with the same process id but different binary's signature. I do not know why this happens.